### PR TITLE
Transform prioritizes over Flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-
-roblox.toml
-selene.toml
-testing.project.json
-*.rbxmx
-.vscode

--- a/src/Copy/TestLoader/Test/CallCopy.lua
+++ b/src/Copy/TestLoader/Test/CallCopy.lua
@@ -66,7 +66,7 @@ return {
 		assert(dict.part ~= newDict.part) --> Clones parts
 		assert(dict.greet == newDict.greet) --> Retains functions
 
-		assert(dict[key] == "value") --> Retains keys
+		assert(newDict[key] == "value") --> Retains keys
 		
 		assert(getmetatable(dict) == getmetatable(newDict)) --> Retains metatables
 		assert(newDict.fakeMember == "does not exist!") --> Retains metamethods

--- a/src/Copy/TestLoader/Test/CallCopy.lua
+++ b/src/Copy/TestLoader/Test/CallCopy.lua
@@ -95,7 +95,7 @@ return {
 				if type_v == "function" then
 					assert(newCopy[k] == v)
 				elseif type_v == "table" then
-					if getDictLen(newCopy[k]) ~= getDictLen(v) and v ~= Copy.Transform then
+					if getDictLen(newCopy[k]) ~= getDictLen(v) and v ~= Copy.Cache then
 						error("Test failed for " .. toBinary(i) .. " at " .. tostring(k) 
 							.. "\nwith " .. tostring(getDictLen(newCopy[k])) .. " == " 
 							.. tostring(getDictLen(v))

--- a/src/Copy/TestLoader/Test/Flags.lua
+++ b/src/Copy/TestLoader/Test/Flags.lua
@@ -63,7 +63,7 @@ return {
 		Copy.Flags.Flush = true
 		local _ = Copy(dict)
 		
-		assert( isEmpty(Copy.Transform) )
+		assert( isEmpty(Copy.Cache) )
 	end,
 	FlushOff = function(Copy)
 		local dict = {
@@ -73,7 +73,7 @@ return {
 		Copy.Flags.Flush = false
 		local _ = Copy(dict)
 		
-		assert( not isEmpty(Copy.Transform) )
+		assert( not isEmpty(Copy.Cache) )
 	end,
 
 	-- relationship between tables and subtables

--- a/src/Copy/TestLoader/Test/Flush.lua
+++ b/src/Copy/TestLoader/Test/Flush.lua
@@ -6,7 +6,7 @@ return {
 		Copy.Flags.Flush = false
 		local newTable1 = Copy(someTable)
 		local newTable2 = Copy(someTable)
-		local storedTable = Copy.Transform[someTable]
+		local storedTable = Copy.Cache[someTable]
 		Copy:Flush()
 		local newTable3 = Copy(someTable)
 		

--- a/src/Copy/TestLoader/Test/OperationSelect.lua
+++ b/src/Copy/TestLoader/Test/OperationSelect.lua
@@ -1,7 +1,7 @@
 --[[
 
 Precedence of modifiers should be as follows:
-Transform > Flags > Operations
+Cache > Flags > Transform
 
 --]]
 

--- a/src/Copy/TestLoader/Test/QueueDelete.lua
+++ b/src/Copy/TestLoader/Test/QueueDelete.lua
@@ -10,7 +10,7 @@ return {
 		assert(newTable.key == nil)
 	end,
 	
-	DeleteMetatables = function(Copy)
+	DeleteMeta = function(Copy)
 		local someTable = {}
 		local someMeta = {}
 		setmetatable(someTable, someMeta)
@@ -33,4 +33,7 @@ return {
 		assert(newTable.key == "value")
 	end,
 
+	AvoidNil = function(Copy)
+		Copy:QueueDelete(1, nil, 3)
+	end,
 }

--- a/src/Copy/TestLoader/Test/QueueForce.lua
+++ b/src/Copy/TestLoader/Test/QueueForce.lua
@@ -51,4 +51,7 @@ return {
 		assert(newMeta == newMeta2)
 	end,
 
+	AvoidNil = function(Copy)
+		Copy:QueueForce(1, nil, 3)
+	end,
 }

--- a/src/Copy/TestLoader/Test/Transform.lua
+++ b/src/Copy/TestLoader/Test/Transform.lua
@@ -4,8 +4,9 @@ return {
 		local array = { "value" }
 		
 		Copy.Transform["value"] = "some other value"
-		
-		assert(Copy(array)[1] == "some other value")
+		local newArray = Copy(array)
+
+		assert(newArray[1] == "some other value")
 	end,
 	
 	Keys = function(Copy)

--- a/src/Copy/TestLoader/Test/init.lua
+++ b/src/Copy/TestLoader/Test/init.lua
@@ -40,11 +40,9 @@ function Test.MakeFactory(copy)
 				__newindex = getmetatable(copy.Flags).__newindex
 			}),
 			Transform = {},
-			
-			Operations = {
-				Delete = {},
-				Force = {},
-			},
+			Cache = {},
+
+			NIL = newproxy(false),
 			
 			Extend = copy.Extend,
 			QueuePreserve = copy.QueuePreserve,
@@ -59,6 +57,7 @@ function Test.MakeFactory(copy)
 end
 
 function testMt:__call(testDict, copy)
+	testDict = testDict or Test.AllTests
 	local factory = Test.MakeFactory(copy)
 	for aspectKey, array in pairs(testDict) do
 		local aspectArray = self.Aspects[aspectKey]

--- a/src/Copy/TestLoader/init.server.lua
+++ b/src/Copy/TestLoader/init.server.lua
@@ -55,13 +55,15 @@ local RUNNING_TESTS = {
 	},
 	QueueDelete = {
 		"DeleteValues",
-		"DeleteMetatables",
+		"DeleteMeta",
 		"DeleteKeySafeguard",
+		"AvoidNil",
 	},
 	QueueForce = {
 		"ForceKeys",
 		"ForceMeta",
 		"ForceMultipleKeys",
+		"AvoidNil",
 	},
 	QueuePreserve = {
 		"Values",


### PR DESCRIPTION
This branch lets `Copy.Transform` take modifier precedence over `Copy.Flags` and creates an internal version of `Transform` known as `Copy.Cache`. This has the advantage of separating self intent from user intent in `Copy.Transform`, which *can* allow for extra flexibility in their shapes and should create a logical hierarchy between context-specific transformations and value-specific transformations.